### PR TITLE
Add variable table cell delimiter (fancy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Improved
 
 -   Live snippets now do so more accents, and spaces
+-   Formatted paste of tables now 'just works' with anything which is tab, comma, or `|` delimited,
+    i.e. spreadsheets, csv, markdown
+-   New setting for custom delimiter for formatted paste to try with tables
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
                 "latex-utilities.formattedPaste.tableColumnDelimiter": {
                     "type": "string",
                     "default": "\t",
-                    "markdownDescription": "Delimiter to use for splitting table cells."
+                    "minLength": 1,
+                    "markdownDescription": "The default delimiter to use for splitting table cells."
                 },
                 "latex-utilities.formattedPaste.tableColumnType": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -78,11 +78,16 @@
         "configuration": {
             "title": "LaTeX Utils",
             "properties": {
-                "latex-utilities.formattedPaste.tableColumnDelimiter": {
+                "latex-utilities.formattedPaste.tableDelimiterDefault": {
                     "type": "string",
                     "default": "\t",
                     "minLength": 1,
                     "markdownDescription": "The default delimiter to use for splitting table cells."
+                },
+                "latex-utilities.formattedPaste.tableDelimiterPrompt": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Whether to be prompted to confirm the table cell delimiter."
                 },
                 "latex-utilities.formattedPaste.tableColumnType": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -78,17 +78,6 @@
         "configuration": {
             "title": "LaTeX Utils",
             "properties": {
-                "latex-utilities.formattedPaste.tableDelimiterDefault": {
-                    "type": "string",
-                    "default": "\t",
-                    "minLength": 1,
-                    "markdownDescription": "The default delimiter to use for splitting table cells."
-                },
-                "latex-utilities.formattedPaste.tableDelimiterPrompt": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Whether to be prompted to confirm the table cell delimiter."
-                },
                 "latex-utilities.formattedPaste.tableColumnType": {
                     "type": "string",
                     "default": "l",
@@ -103,6 +92,17 @@
                     "type": "integer",
                     "default": 1,
                     "markdownDescription": "Number of header rows to assume. Set to **`0`** to disable."
+                },
+                "latex-utilities.formattedPaste.customTableDelimiter": {
+                    "type": "string",
+                    "default": "\t",
+                    "minLength": 1,
+                    "markdownDescription": "A custom delimiter to try for tables (in addition to `\\t`, `,` and `|` which we always try)"
+                },
+                "latex-utilities.formattedPaste.tableDelimiterPrompt": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Whether to be prompted for a custom delimiter if the set table delimiters didn't work"
                 },
                 "latex-utilities.formattedPaste.maxLineLength": {
                     "type": "integer",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
         "configuration": {
             "title": "LaTeX Utils",
             "properties": {
+                "latex-utilities.formattedPaste.tableColumnDelimiter": {
+                    "type": "string",
+                    "default": "\t",
+                    "markdownDescription": "Delimiter to use for splitting table cells."
+                },
                 "latex-utilities.formattedPaste.tableColumnType": {
                     "type": "string",
                     "default": "l",

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -118,7 +118,7 @@ export class Paster {
                 .replace(/^[\uFEFF\xA0]+|[\uFEFF\xA0]+$/gm, '')
         content = trimUnwantedWhitespace(content)
 
-        const TEST_DELIMITERS = ['\t', ',']
+        const TEST_DELIMITERS = new Set([columnDelimiter, '\t', ','])
         const tables: string[][][] = []
 
         for (const delimiter of TEST_DELIMITERS) {
@@ -143,7 +143,6 @@ export class Paster {
                 if (columnDelimiterNew === undefined) {
                     throw new Error('no table cell delimiter set')
                 }
-                columnDelimiter = columnDelimiterNew
 
                 try {
                     const table = await this.processTable(content, columnDelimiterNew)

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -159,7 +159,7 @@ export class Paster {
 
         // put the 'biggest' table first
         tables.sort((a, b) => a.length * a[0].length - b.length * b[0].length)
-        const table = tables[0].map(row => row.map(cell => this.reformatText(cell, false)))
+        const table = tables[0].map(row => row.map(cell => this.reformatText(cell.replace(/^\s+|\s+$/gm, ''), false)))
 
         const tabularRows = table.map(row => '\t' + row.join(' & '))
 

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -106,7 +106,7 @@ export class Paster {
         this.extension.logger.addLogMessage('Pasting: Table')
         const configuration = vscode.workspace.getConfiguration('latex-utilities.formattedPaste')
 
-        let columnDelimiter: string = delimiter || configuration.tableDelimiterDefault
+        let columnDelimiter: string = delimiter || configuration.customTableDelimiter
         const columnType: string = configuration.tableColumnType
         const booktabs: boolean = configuration.tableBooktabsStyle
         const headerRows: number = configuration.tableHeaderRows

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -109,12 +109,20 @@ export class Paster {
 
     public pasteTable(editor: vscode.TextEditor, content: string) {
         this.extension.logger.addLogMessage('Pasting: Table')
+
+        const configuration = vscode.workspace.getConfiguration('latex-utilities.formattedPaste')
+
+        const columnDelimiter: string = configuration.tableColumnDelimiter
+        const columnType: string = configuration.tableColumnType
+        const booktabs: boolean = configuration.tableBooktabsStyle
+        const headerRows: number = configuration.tableHeaderRows
+
         const trimUnwantedWhitespace = (s: string) =>
             s.replace(/^[^\S\t]+|[^\S\t]+$/gm, '').replace(/^[\uFEFF\xA0]+|[\uFEFF\xA0]+$/gm, '')
         content = trimUnwantedWhitespace(content)
         content = this.reformatText(content, false)
         const lines = content.split('\n')
-        const cells = lines.map(l => l.split('\t'))
+        const cells = lines.map(l => l.split(columnDelimiter))
 
         // determine if all rows have same number of cells
         const isConsistent = cells.reduce((accumulator, current, _index, array) => {
@@ -129,12 +137,6 @@ export class Paster {
         } else if (cells.length === 1 || cells[0].length === 1) {
             throw 'Doesn\'t look like a table'
         }
-
-        const configuration = vscode.workspace.getConfiguration('latex-utilities.formattedPaste')
-
-        const columnType: string = configuration.tableColumnType
-        const booktabs: boolean = configuration.tableBooktabsStyle
-        const headerRows: number = configuration.tableHeaderRows
 
         const tabularRows = cells.map(row => '\t' + row.join(' & '))
 

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -100,7 +100,7 @@ export class Paster {
         }
     }
 
-    public async pasteTable(editor: vscode.TextEditor, content: string, delimiter: string|undefined = undefined) {
+    public async pasteTable(editor: vscode.TextEditor, content: string, delimiter?: string|undefined) {
         this.extension.logger.addLogMessage('Pasting: Table')
 
         const configuration = vscode.workspace.getConfiguration('latex-utilities.formattedPaste')
@@ -120,7 +120,7 @@ export class Paster {
         });
 
         if(columnDelimiter === undefined){
-            throw 'no table cell delimiter set'
+            throw new Error('no table cell delimiter set')
         }
 
         const trimUnwantedWhitespace = (s: string) =>

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -105,22 +105,24 @@ export class Paster {
 
         const configuration = vscode.workspace.getConfiguration('latex-utilities.formattedPaste')
 
-        const columnDelimiterDefault: string = delimiter || configuration.tableColumnDelimiter
+        let columnDelimiter: string = delimiter || configuration.tableDelimiterDefault
         const columnType: string = configuration.tableColumnType
         const booktabs: boolean = configuration.tableBooktabsStyle
         const headerRows: number = configuration.tableHeaderRows
 
-        const columnDelimiter = await vscode.window.showInputBox({
-            prompt: "Please specify the table cell delimiter",
-            value: columnDelimiterDefault,
-            placeHolder: columnDelimiterDefault,
-            validateInput: (text: string) => {
-                return text === '' ? 'No delimiter specified!' : null;
+        if (configuration.tableDelimiterPrompt) {
+            const columnDelimiterNew = await vscode.window.showInputBox({
+                prompt: "Please specify the table cell delimiter",
+                value: columnDelimiter,
+                placeHolder: columnDelimiter,
+                validateInput: (text: string) => {
+                    return text === '' ? 'No delimiter specified!' : null;
+                }
+            });
+            if(columnDelimiterNew === undefined){
+                throw new Error('no table cell delimiter set')
             }
-        });
-
-        if(columnDelimiter === undefined){
-            throw new Error('no table cell delimiter set')
+            columnDelimiter = columnDelimiterNew
         }
 
         const trimUnwantedWhitespace = (s: string) =>

--- a/src/components/paster.ts
+++ b/src/components/paster.ts
@@ -102,7 +102,6 @@ export class Paster {
 
     public async pasteTable(editor: vscode.TextEditor, content: string, delimiter?: string|undefined) {
         this.extension.logger.addLogMessage('Pasting: Table')
-
         const configuration = vscode.workspace.getConfiguration('latex-utilities.formattedPaste')
 
         let columnDelimiter: string = delimiter || configuration.tableDelimiterDefault
@@ -124,9 +123,8 @@ export class Paster {
             }
             columnDelimiter = columnDelimiterNew
         }
-
         const trimUnwantedWhitespace = (s: string) =>
-            s.replace(/^[^\S\t]+|[^\S\t]+$/gm, '').replace(/^[\uFEFF\xA0]+|[\uFEFF\xA0]+$/gm, '')
+            s.replace('\r\n', '\n').replace(/^[^\S\t]+|[^\S\t]+$/gm, '').replace(/^[\uFEFF\xA0]+|[\uFEFF\xA0]+$/gm, '')
         content = trimUnwantedWhitespace(content)
         content = this.reformatText(content, false)
         const lines = content.split('\n')


### PR DESCRIPTION
This is the 'fancy' fix for #56

Here I add a user prompt to allow for the delimiter to be changed.
This required converting `pasteTable` to an `async` function,
and `csv-parser` is no longer used to pre-convert `'` delimiters to `\t` when converting csv files.