### PR TITLE
Support Pasting Image File

### DIFF
--- a/scripts/saveclipimg-pc.ps1
+++ b/scripts/saveclipimg-pc.ps1
@@ -5,7 +5,13 @@ param($imagePath)
 # Adapted from https://github.com/octan3/img-clipboard-dump/blob/master/dump-clipboard-png.ps1
 
 Add-Type -Assembly PresentationCore
-$img = [Windows.Clipboard]::GetImage()
+$file = Get-Clipboard -Format FileDropList
+if ($file -ne $null) {
+    $img = new-object System.Drawing.Bitmap($file[0].Fullname)
+} else {
+    $img = Get-Clipboard -Format Image
+}
+
 
 if ($img -eq $null) {
     "no image"
@@ -17,11 +23,6 @@ if (-not $imagePath) {
     Exit 1
 }
 
-$fcb = new-object Windows.Media.Imaging.FormatConvertedBitmap($img, [Windows.Media.PixelFormats]::Rgb24, $null, 0)
-$stream = [IO.File]::Open($imagePath, "OpenOrCreate")
-$encoder = New-Object Windows.Media.Imaging.PngBitmapEncoder
-$encoder.Frames.Add([Windows.Media.Imaging.BitmapFrame]::Create($fcb)) | out-null
-$encoder.Save($stream) | out-null
-$stream.Dispose() | out-null
+$img.save($imagePath)
 
 $imagePath

--- a/scripts/saveclipimg-pc.ps1
+++ b/scripts/saveclipimg-pc.ps1
@@ -5,24 +5,47 @@ param($imagePath)
 # Adapted from https://github.com/octan3/img-clipboard-dump/blob/master/dump-clipboard-png.ps1
 
 Add-Type -Assembly PresentationCore
-$file = Get-Clipboard -Format FileDropList
-if ($file -ne $null) {
-    $img = new-object System.Drawing.Bitmap($file[0].Fullname)
-} else {
-    $img = Get-Clipboard -Format Image
+
+if ($PSVersionTable.PSVersion.Major -ge 5 -and $PSVersionTable.PSVersion.Major -ge 1)
+{
+    $file = Get-Clipboard -Format FileDropList
+    if ($file -ne $null) {
+        $img = new-object System.Drawing.Bitmap($file[0].Fullname)
+    } else {
+        $img = Get-Clipboard -Format Image
+    }
+
+    if ($img -eq $null) {
+        "no image"
+        Exit 1
+    }
+
+    if (-not $imagePath) {
+        "no image"
+        Exit 1
+    }
+
+    $img.save($imagePath)
 }
+else
+{
+    $img = [Windows.Clipboard]::GetImage()
+    if ($img -eq $null) {
+        "no image"
+        Exit 1
+    }
 
+    if (-not $imagePath) {
+        "no image"
+        Exit 1
+    }
 
-if ($img -eq $null) {
-    "no image"
-    Exit 1
+    $fcb = new-object Windows.Media.Imaging.FormatConvertedBitmap($img, [Windows.Media.PixelFormats]::Rgb24, $null, 0)
+    $stream = [IO.File]::Open($imagePath, "OpenOrCreate")
+    $encoder = New-Object Windows.Media.Imaging.PngBitmapEncoder
+    $encoder.Frames.Add([Windows.Media.Imaging.BitmapFrame]::Create($fcb)) | out-null
+    $encoder.Save($stream) | out-null
+    $stream.Dispose() | out-null
 }
-
-if (-not $imagePath) {
-    "no image"
-    Exit 1
-}
-
-$img.save($imagePath)
 
 $imagePath


### PR DESCRIPTION
This PR modify the `saveclipimg-pc.ps1` script, using the `Get-Clipboard` command introduced in PowerShell 5.1, to auto-detect whether the image in clipboard (if exists) is a file or a bitmap, and save it to specific path. However, MacOS and Linux have not yet been supported.