### PR TITLE
Fixed Live Snippet Cursor Steps out of Parentheses

### DIFF
--- a/src/components/completionWatcher.ts
+++ b/src/components/completionWatcher.ts
@@ -211,12 +211,6 @@ export class CompletionWatcher {
                             )
                             .then(() => {
                                 const offset = replacement.length - match[0].length;
-                                if (vscode.window.activeTextEditor && offset > 0) {
-                                    vscode.window.activeTextEditor.selection = new vscode.Selection(
-                                        vscode.window.activeTextEditor.selection.anchor.translate(0, offset),
-                                        vscode.window.activeTextEditor.selection.anchor.translate(0, offset)
-                                    );
-                                }
                                 this.currentlyExecutingChange = false;
                                 debuglog(' ▹', changeStart, 'to perform text replacement');
                                 resolve(offset);


### PR DESCRIPTION
Closes #384 

I don't know what the purpose of the removed lines was. It seems like they were there to compensate for the additional characters added by the replacement however I found that vscode handled the cursor placement fine on its own. So instead of fixing a problem, these lines were creating an issue by moving the cursor forward after the snippet has been inserted. This often led to the cursor being moved outside of parentheses and even the math mode entirely which was quite annoying to deal with