### PR TITLE
fix(texdef): improve error handling, set CWD, and add `--tex` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -694,6 +694,19 @@
                     "default": "true",
                     "markdownDescription": "Use `texdef` to find definitions for LaTeX macros"
                 },
+                "latex-utilities.texdef.tex": {
+                    "type": "string",
+                    "default": "latex",
+                    "enum": [
+                        "latex",
+                        "tex",
+                        "luatex",
+                        "lualatex",
+                        "xetex",
+                        "xelatex"
+                    ],
+                    "markdownDescription": "Sets the `--tex <format>` option of the `texdef` command. This determines the TeX format used when resolving LaTeX macro definitions."
+                },
                 "latex-utilities.zotero.zoteroUrl": {
                     "type": "string",
                     "default": "http://localhost:23119",

--- a/src/providers/macroDefinitions.ts
+++ b/src/providers/macroDefinitions.ts
@@ -44,8 +44,8 @@ export class MacroDefinitions implements vscode.DefinitionProvider {
             }
 
             checkCommandExists('texdef')
-
-            const texdefOptions = ['--source', '--Find', '--tex', 'latex']
+            const texdefFormat = vscode.workspace.getConfiguration('latex-utilities.texdef').get<string>('tex') ?? 'latex'
+            const texdefOptions = ['--source', '--Find', '--tex', texdefFormat]
             const packages = this.extension.manager.usedPackages(document)
             if (/\.sty$/.test(document.uri.fsPath)) {
                 texdefOptions.push(document.uri.fsPath.replace(/\.sty$/, ''))

--- a/src/providers/macroDefinitions.ts
+++ b/src/providers/macroDefinitions.ts
@@ -102,8 +102,10 @@ export class MacroDefinitions implements vscode.DefinitionProvider {
                     cmdProcess.kill()
                     resolve(data.toString())
                 })
-                cmdProcess.stdout.on('error', () => {
-                    this.extension.logger.addLogMessage(`Error running texdef for ${options[options.length - 1]}}`)
+                cmdProcess.stderr.on('data', (data) => {
+                    const errorMessage = data.toString().replaceAll('\n', '')
+                    this.extension.logger.addLogMessage(`Error running texdef for ${options[options.length - 1]} ${errorMessage}`)
+                    cmdProcess.kill()
                     resolve('')
                 })
                 cmdProcess.stdout.on('end', () => {

--- a/src/providers/macroDefinitions.ts
+++ b/src/providers/macroDefinitions.ts
@@ -107,8 +107,6 @@ export class MacroDefinitions implements vscode.DefinitionProvider {
                 cmdProcess.stderr.on('data', (data) => {
                     const errorMessage = data.toString().replaceAll('\n', '')
                     this.extension.logger.addLogMessage(`Error running texdef for ${options[options.length - 1]} ${errorMessage}`)
-                    cmdProcess.kill()
-                    resolve('')
                 })
                 cmdProcess.stdout.on('end', () => {
                     resolve('')


### PR DESCRIPTION
Fixes #407. For reproduction steps, see #407 and [texdef-fontspec-repro](https://github.com/mcontrib/texdef-fontspec-repro).

### Before and After

| **Before** | **After** |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/08cf2292-f8b3-43fe-9a75-bf38b79c8313" /> | <video src="https://github.com/user-attachments/assets/ae76434f-3e18-484b-a9a7-e5577639e48e" />   |

### Description

While investigating why `texdef` couldn’t resolve macros defined in `.cls` files within the same folder, I manually ran the logged `texdef` command and confirmed it worked as expected. However, in the extension, the spawned process exited immediately without any output.

Debugging revealed the following issues:

- **Issue 1:** We were listening on `stdout.on('error')`, but error messages from `texdef` are emitted via `stderr.on('data')`, so errors were never caught.  
    https://github.com/tecosaur/LaTeX-Utilities/blob/a3265cc6827bd383eac4945ea8b914c0b4896fa0/src/providers/macroDefinitions.ts#L105-L108
- **Issue 2:** The spawned process did not have the correct working directory (`cwd`), which prevented it from accessing files in the workspace folder. 
  - Based on testing, the default `cwd` on macOS is `/`, while on Windows, it defaults to the VS Code directory.
  - https://github.com/tecosaur/LaTeX-Utilities/blob/a3265cc6827bd383eac4945ea8b914c0b4896fa0/src/providers/macroDefinitions.ts#L96
- **Issue 3:** Some packages (e.g., `fontspec`) require an engine like `xelatex`, but `texdef` defaults to `latex`.

### Summary of Changes

- Fixed error handling by switching from `stdout.on('error')` to `stderr.on('data')`, since `stdout` and `stderr` can appear simultaneously (confirmed by testing), so no early return on `stderr`.
- Added `cwd` to `spawn` options to ensure `texdef` runs in the correct context.
- Introduced a new configuration option `latex-utilities.texdef.tex` to set the `--tex` argument.


### Future Improvements

- Automatically detect the correct engine based on the project context.
- Provide user feedback if `texdef` fails due to an incompatible engine.
- Should we cache the result of `texdef`?