### PR TITLE
Fix a bug where trying to undo a change results in a loop

### DIFF
--- a/src/components/completionWatcher.ts
+++ b/src/components/completionWatcher.ts
@@ -107,6 +107,10 @@ export class CompletionWatcher {
     }
 
     public async watcher(e: vscode.TextDocumentChangeEvent) {
+        if (e.reason == vscode.TextDocumentChangeReason.Undo) {
+            return
+        }
+        
         if (+new Date() - this.configAge > this.MAX_CONFIG_AGE) {
             this.enabled = vscode.workspace.getConfiguration('latex-utilities').get('liveReformat.enabled') as boolean
             this.loadSnippets()


### PR DESCRIPTION
There is a bug when undoing completitions with Ctrl + Z that causes the change to be removed but immediately reapplies right after, locking the user in an undo loop and removing the ability to restore the document to it's previous state using just undo actions.